### PR TITLE
Sign Changes

### DIFF
--- a/core/src/main/java/com/ryderbelserion/map/config/SignsConfig.java
+++ b/core/src/main/java/com/ryderbelserion/map/config/SignsConfig.java
@@ -233,6 +233,9 @@ public class SignsConfig extends AbstractConfig {
             The sound to play when a sign is removed from Pl3xMap.
             https://minecraft.wiki/w/Sounds.json#Java_Edition_values""")
     public String SIGN_REMOVE_SOUND = "entity.ghast.hurt";
+    @Key("sign.block-place")
+    @Comment("Should signs be displayed on block place?")
+    public boolean SIGN_BLOCK_PLACE = true;
 
     private final World world;
 

--- a/paper/src/main/java/com/ryderbelserion/map/listener/signs/SignListener.java
+++ b/paper/src/main/java/com/ryderbelserion/map/listener/signs/SignListener.java
@@ -123,13 +123,7 @@ public class SignListener implements Listener {
                 // cancel event to stop sign editor from opening
                 event.setCancelled(true);
 
-                BlockFace facing = event.getBlockFace();
-
-                if (state.getBlockData() instanceof Directional directional) {
-                    facing = directional.getFacing();
-                }
-
-                tryAddSign(sign, sign.getSide(event.getBlockFace() == facing ? Side.FRONT : Side.BACK));
+                tryAddSign(sign, sign.getTargetSide(event.getPlayer()));
             }
         }
     }

--- a/paper/src/main/java/com/ryderbelserion/map/listener/signs/SignListener.java
+++ b/paper/src/main/java/com/ryderbelserion/map/listener/signs/SignListener.java
@@ -68,7 +68,11 @@ public class SignListener implements Listener {
             return;
         }
 
-        tryAddSign(state, pos, event.getSide());
+        if (!(state instanceof org.bukkit.block.Sign sign)) {
+            return;
+        }
+
+        tryAddSign(sign, pos, List.of(event.getLines()));
     }
 
 
@@ -179,21 +183,15 @@ public class SignListener implements Listener {
         tryRemoveSign(event.getToBlock().getState());
     }
 
-    private void tryAddSign(@NotNull final BlockState state, @NotNull final Position pos, @NotNull final Side side) {
-        if (state instanceof org.bukkit.block.Sign sign) {
-            tryAddSign(sign, pos, sign.getSide(side));
-        }
-    }
-
     private void tryAddSign(@NotNull final BlockState state, @NotNull final SignSide side) {
         if (state instanceof org.bukkit.block.Sign sign) {
             Location loc = sign.getLocation();
             Position pos = new Position(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
-            tryAddSign(sign, pos, side);
+            tryAddSign(sign, pos, getLines(side));
         }
     }
 
-    private void tryAddSign(@NotNull final org.bukkit.block.Sign sign, @NotNull final Position pos, @NotNull final SignSide side) {
+    private void tryAddSign(@NotNull final org.bukkit.block.Sign sign, @NotNull final Position pos, List<String> lines) {
         final SignsLayer layer = getLayer(sign);
 
         if (layer == null) {
@@ -209,7 +207,7 @@ public class SignListener implements Listener {
         }
 
         // add sign to layer
-        layer.putSign(new Sign(pos, icon, getLines(side)));
+        layer.putSign(new Sign(pos, icon, lines));
 
         // play fancy particles as visualizer
         particles(sign.getLocation(), ItemUtil.getParticleType(layer.getConfig().SIGN_ADD_PARTICLES), ItemUtil.getSound(layer.getConfig().SIGN_ADD_SOUND));


### PR DESCRIPTION
This PR does the following:

- Fixes an issue where editing the sign wouldn't properly update the text on the signs shown on the map
- retrieve the correct side of the sign when adding to the web map
- add new `sign.block-place` config option that's true by default (closes #12)