### PR TITLE
Fix WorldGuard hook not showing region owners and members

### DIFF
--- a/paper/src/main/java/com/ryderbelserion/map/hook/claims/worldguard/WorldGuardHook.java
+++ b/paper/src/main/java/com/ryderbelserion/map/hook/claims/worldguard/WorldGuardHook.java
@@ -2,6 +2,7 @@ package com.ryderbelserion.map.hook.claims.worldguard;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.ryderbelserion.map.Pl3xMapExtras;
 import com.ryderbelserion.map.hook.Hook;
 import com.ryderbelserion.map.util.ConfigUtil;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -22,10 +23,14 @@ import net.pl3x.map.core.markers.option.Options;
 import net.pl3x.map.core.util.Colors;
 import net.pl3x.map.core.world.World;
 import org.bukkit.Bukkit;
+import org.bukkit.plugin.java.JavaPlugin;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class WorldGuardHook implements Hook {
+
+    private final Pl3xMapExtras plugin = (Pl3xMapExtras) JavaPlugin.getProvidingPlugin(Pl3xMapExtras.class);
 
     private final Cache<UUID, String> userCache = CacheBuilder.newBuilder()
             .expireAfterAccess(30, TimeUnit.MINUTES)
@@ -111,7 +116,7 @@ public class WorldGuardHook implements Hook {
             if (username != null) {
                 return username;
             }
-            username = Bukkit.getOfflinePlayer(uniqueId).getName();
+            username = plugin.getServer().getOfflinePlayer(uniqueId).getName();
             if (username != null) {
                 userCache.put(uniqueId, username);
                 return username;
@@ -132,7 +137,7 @@ public class WorldGuardHook implements Hook {
             if (username != null) {
                 return username;
             }
-            username = Bukkit.getOfflinePlayer(uniqueId).getName();
+            username = plugin.getServer().getOfflinePlayer(uniqueId).getName();
             if (username != null) {
                 userCache.put(uniqueId, username);
                 return username;


### PR DESCRIPTION
Currently, the hook uses WorldGuard's `DefaultDomain#getPlayers` method which only returns members / owners that were added by their username. This PR also retrieves region users from UUIDs.

- Owners and members will have their name appear in the popup if available. (Defaults to UUID when not available)
- Player names are cached for 30 minutes after last access so that `OfflinePlayer` object is not created each time data is requested.
- Using static `Bukkit#getOfflinePlayer` because neither plugin instance nor `Server` object seem to be easily accessible with how hooks are constructed. Let me know if you know a proper way to change this however. (Or you can also push to this PR, because I think it'll require more structure changes than I'd like to target myself)

Tested on 1.21.8 and appears to be working perfectly fine.